### PR TITLE
feat: adaugare adresa completa pentru localitati

### DIFF
--- a/ROMANIA/ALBA/municipiialba.php
+++ b/ROMANIA/ALBA/municipiialba.php
@@ -7,7 +7,7 @@ $municipii =
                     createLoc("Micești", "sat"),
                     createLoc("Oarda", "sat"),
                     createLoc("Pâclișa", "sat"),
-                ]),
+                ], createAdresaCompleta("municipiul ALBA IULIA, judetul ALBA, România")),
                 createMunicipiu("AIUD",[
 				    createLoc("AIUD", "oras",[
 					   createLoc("Ciumbrud", "sat"),

--- a/ROMANIA/functions.php
+++ b/ROMANIA/functions.php
@@ -1,14 +1,17 @@
 <?php
 
 if (!function_exists('createLoc')) {
-function createLoc($nume, $tip, $locuri = []) {
+function createLoc($nume, $tip, $locuri = [], $adresaCompleta = null) {
     $loc = new stdClass();
     $loc->nume = $nume;
     $loc->tip = $tip;
 
-    // Set the loc property only if $locuri is defined and not an empty array
     if (!empty($locuri)) {
         $loc->localitate = $locuri;
+    }
+
+    if ($adresaCompleta !== null) {
+        $loc->adresaCompleta = $adresaCompleta;
     }
 
     return $loc;
@@ -17,31 +20,52 @@ function createLoc($nume, $tip, $locuri = []) {
 
 
 if (!function_exists('createComuna')) {
-function createComuna($nume, $locuri = []) {
+function createComuna($nume, $locuri = [], $adresaCompleta = null) {
     $comuna = new stdClass();
     $comuna->nume = $nume;
     $comuna->localitate = $locuri;
+    if ($adresaCompleta !== null) {
+        $comuna->adresaCompleta = $adresaCompleta;
+    }
     return $comuna;
 }
 }
 
 if (!function_exists('createOras')) {
-function createOras($nume, $locuri = []) {
+function createOras($nume, $locuri = [], $adresaCompleta = null) {
     $oras = new stdClass();
     $oras->nume = $nume;
     $oras->localitate = $locuri;
+    if ($adresaCompleta !== null) {
+        $oras->adresaCompleta = $adresaCompleta;
+    }
     return $oras;
 }
 }
 
 
+if (!function_exists('createAdresaCompleta')) {
+function createAdresaCompleta($adresaCuDiacritice) {
+    $adresaFaraDiacritice = str_replace(
+        ['ă', 'â', 'ș', 'ț', 'Ă', 'Â', 'Ș', 'Ț', 'é', 'É', 'î', 'Î'],
+        ['a', 'a', 's', 't', 'A', 'A', 'S', 'T', 'e', 'E', 'i', 'I'],
+        $adresaCuDiacritice
+    );
+    return [$adresaCuDiacritice, $adresaFaraDiacritice];
+}
+}
+
 if (!function_exists('createMunicipiu')) {
-function createMunicipiu($nume, $locuri = []) {
+function createMunicipiu($nume, $locuri = [], $adresaCompleta = null) {
     $municipiu = new stdClass();
     $municipiu->nume = $nume;
 	
 	   if (!empty($locuri)) {
         $municipiu->localitate = $locuri;
+    }
+    
+    if ($adresaCompleta !== null) {
+        $municipiu->adresaCompleta = $adresaCompleta;
     }
  
     return $municipiu;


### PR DESCRIPTION
## Summary
- Am adaugat functia `createAdresaCompleta()` care genereaza automat atat versiunea cu diacritice, cat si cea fara diacritice
- Am actualizat `createMunicipiu`, `createOras`, `createComuna` si `createLoc` pentru a suporta parametrul optional `adresaCompleta`
- Am testat implementarea cu municipiul ALBA IULIA din judetul ALBA

## Detalii implementare
- Functia `createAdresaCompleta($adresaCuDiacritice)` returneaza un array cu 2 elemente:
  - Primul element: adresa cu diacritice (ex: &quot;municipiul ZALĂU, judetul SĂLAJ, România&quot;)
  - Al doilea element: adresa fara diacritice (ex: &quot;municipiul ZALAU, judetul SALAJ, Romania&quot;)
- Diacritice suportate: ă, â, ș, ț, î (si variantele majuscule)

## Exemplu de utilizare
```php
createMunicipiu(&quot;ALBA IULIA&quot;, [
    createLoc(&quot;ALBA IULIA&quot;, &quot;oras&quot;),
    createLoc(&quot;Bărăbanț&quot;, &quot;sat&quot;),
], createAdresaCompleta(&quot;municipiul ALBA IULIA, judetul ALBA, România&quot;))
```

## Issue related
Se relationeaza cu issue #208 - Adaugare -- adresa completa -- pentru fiecare localitate