### PR TITLE
feat: add JSON_UNESCAPED_UNICODE for readable output

### DIFF
--- a/ROMANIA/index.php
+++ b/ROMANIA/index.php
@@ -73,5 +73,5 @@ $tara = createTara(
     "https://legislatie.just.ro/Public/DetaliiDocument/189",
     "România",$judete,$bucuresti);
 	
-echo json_encode($tara, JSON_PRETTY_PRINT);
+echo json_encode($tara, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 ?>


### PR DESCRIPTION
## Descriere
- Adăugare flag JSON_UNESCAPED_UNICODE la json_encode pentru a afișa caracterele românești (ă, â, ș, ț) în loc de coduri escape

Closes #259