### PR TITLE
fix: UTF-8 regex modifier for diacritics search

### DIFF
--- a/search/index.php
+++ b/search/index.php
@@ -114,7 +114,7 @@ foreach ($judeteFolderMap as $folderName => $judetNume) {
 
         $content = file_get_contents($filePath);
         
-        $pattern = '/create(Oras|Municipiu)\("([^"]+)"/i';
+        $pattern = '/create(Oras|Municipiu)\("([^"]+)"/iu';
         if (preg_match_all($pattern, $content, $matches)) {
             foreach ($matches[2] as $orasName) {
                 $orasNameNormalized = removeDiacritics(strtolower($orasName));
@@ -133,7 +133,7 @@ foreach ($judeteFolderMap as $folderName => $judetNume) {
     $comunaFilePath = $judetPath . '/comune.php';
     if (file_exists($comunaFilePath)) {
         $content = file_get_contents($comunaFilePath);
-        $pattern = '/createComuna\("([^"]+)"/i';
+        $pattern = '/createComuna\("([^"]+)"/iu';
         if (preg_match_all($pattern, $content, $matches)) {
             foreach ($matches[1] as $comunaName) {
                 $comunaNameNormalized = removeDiacritics(strtolower($comunaName));


### PR DESCRIPTION
## Rezumat
- Adaugare flag 'u' (UTF-8) la regex patterns pentru a permite cautarea cu diacritice
- Fix pentru cautarea "Zalau" care acum gaseste "ZALĂU"