### PR TITLE
feat: add optional judet filter parameter to search API

### DIFF
--- a/search/index.php
+++ b/search/index.php
@@ -5,10 +5,17 @@ header("Content-Type: application/json");
 include_once __DIR__ . '/../util/functions.php';
 
 $query = isset($_GET['q']) ? trim($_GET['q']) : '';
+$judetFilter = isset($_GET['judet']) ? trim($_GET['judet']) : null;
 
 if (empty($query)) {
     echo json_encode(["error" => "Parametrul 'q' este obligatoriu"], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
     exit;
+}
+
+// Normalize judet filter if provided
+$judetFilterUpper = null;
+if ($judetFilter !== null) {
+    $judetFilterUpper = strtoupper(removeDiacritics($judetFilter));
 }
 
 $judeteMap = [
@@ -179,6 +186,27 @@ foreach ($judeteResults as $j) {
 // Add other results
 foreach ($results as $r) {
     $allResults[] = $r;
+}
+
+// Filter by judet if provided
+if ($judetFilterUpper !== null) {
+    $filteredResults = [];
+    foreach ($allResults as $r) {
+        if ($r['type'] === 'judet') {
+            $judetNameUpper = strtoupper(removeDiacritics($r['data']['nume']));
+            $judetDiacUpper = strtoupper(removeDiacritics($r['data']['numeDiacritice'] ?? $r['data']['nume']));
+            if ($judetNameUpper === $judetFilterUpper || $judetDiacUpper === $judetFilterUpper) {
+                $filteredResults[] = $r;
+            }
+        } else {
+            $resultJudetName = strtoupper(removeDiacritics($r['data']['judet']['nume']));
+            $resultJudetDiac = strtoupper(removeDiacritics($r['data']['judet']['numeDiacritice'] ?? $r['data']['judet']['nume']));
+            if ($resultJudetName === $judetFilterUpper || $resultJudetDiac === $judetFilterUpper) {
+                $filteredResults[] = $r;
+            }
+        }
+    }
+    $allResults = $filteredResults;
 }
 
 if (count($allResults) === 0) {


### PR DESCRIPTION
## Summary
- Added optional `judet` query parameter to search endpoint
- Allows filtering results by a specific county
- Accepts both diacritics and non-diacritics versions

## Usage

```bash
# Search for \"Alba\" in Alba county only
curl \"http://localhost:8080/search/index.php?q=Alba&judet=Alba\"

# Search for \"Huta\" in Bihor only
curl \"http://localhost:8080/search/index.php?q=Huta&judet=Bihor\"

# Search for \"Cluj-Napoca\" in Cluj county
curl \"http://localhost:8080/search/index.php?q=Cluj-Napoca&judet=Cluj\"
```

## Tests

- `?q=Alba` → 3 results (judet + 2 sate)
- `?q=Alba&judet=Alba` → 1 result (judet only)
- `?q=Alba&judet=Cluj` → 0 results (correct - no \"Alba\" in Cluj)
- `?q=Huta` → 3 results (Bihor, Cluj, Salaj)
- `?q=Huta&judet=Bihor` → 1 result

Closes #284