### PR TITLE
fix: normalize query by removing diacritics for case-insensitive search (#291)

### DIFF
--- a/search/index.php
+++ b/search/index.php
@@ -63,7 +63,7 @@ $judeteMap = [
     'BUCURESTI' => ["nume" => "Bucuresti", "numeDiacritice" => "București", "cod" => "B"]
 ];
 
-$queryUpper = strtoupper($query);
+$queryUpper = strtoupper(removeDiacritics($query));
 
 // Search for judete first - exact match only
 $judeteResults = [];


### PR DESCRIPTION
## Summary

Fixed case sensitivity issue when using the judet filter in search.

## Problem

When searching with the judet filter, queries were case-sensitive. For example:
- `?q=Harlaul&judet=Iasi` returned 0 results
- `?q=HARLAU&judet=Iasi` returned 1 result (HÂRLĂU)

## Solution

Normalize the query by removing diacritics before comparison:
```php
// Before
$queryUpper = strtoupper($query);

// After
$queryUpper = strtoupper(removeDiacritics($query));
```

## Testing

This ensures case-insensitive AND diacritic-insensitive matching when using the judet filter.

Fixes #291