### PR TITLE
docs: add e2e test status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # API Localități din România
 
+[![E2E Tests](https://img.shields.io/github/actions/workflow/status/peviitor-ro/orase/api-tests.yml?branch=main&label=E2E%20Tests)](https://github.com/peviitor-ro/orase/actions/workflows/api-tests.yml)
+
 Un API public care oferă informații despre toate localitățile din România: comune, municipii, orașe și sate.
 
 ## 🌐 Endpoint-uri


### PR DESCRIPTION
## Summary
Add GitHub Actions e2e test status badge to README.md

## Changes
- Added shields.io workflow status badge after title
- Badge shows e2e test status for main branch
- Clicking badge links to GitHub Actions workflow

## Closes
- #304